### PR TITLE
Update 10-wait-docker.conf

### DIFF
--- a/10-wait-docker.conf
+++ b/10-wait-docker.conf
@@ -1,3 +1,3 @@
 [Unit]
-After=network.target docker.socket firewalld.service etcd2.service
-Requires=docker.socket etcd2.service
+After=network.target docker.socket firewalld.service etcd2.service rbd-docker-plugin.service
+Requires=docker.socket etcd2.service rbd-docker-plugin.service


### PR DESCRIPTION


Fix a bug, and when rbd-docker-plugin service is restarted, RBD volume is locked。
